### PR TITLE
Add Personal Access Tokens for App authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /.idea
 /target
 /.docker_volumes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "rocket",
  "rocket_cors",
  "serde",
+ "uuid",
  "vergen",
 ]
 
@@ -1948,6 +1949,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Backend for the Minne app"
 repository = "https://github.com/flying7eleven/minne-backend"
 readme = "README.md"
 license-file = "LICENSE.md"
-rust-version = "1.66"
+rust-version = "1.67"
 build = "build.rs"
 
 [dependencies.bcrypt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,11 @@ default-features = false
 version = "1.0.152"
 default-features = false
 
+[dependencies.uuid]
+version = "1.2.2"
+default-features = false
+features = ["v4"]
+
 [build-dependencies.vergen]
 version = "7.5.0"
 default-features = false

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Build the backend container by going into the root directory of the repository a
 ### Use the stored access token to fetch all tasks of the logged-in user
 `curl --verbose http://127.0.0.1:5842/v1/task/list -H @access_token.tmp`
 
+### Create a new Personal Access Token (PAT) for the logged-in user
+`curl --verbose http://127.0.0.1:5842/v1/auth/pat -H "Content-Type: application/json" -H @access_token.tmp --data "{\"name\": \"A descriptive name for the PAT\"}"`
+
 ## Environment Variables
 - `MINNE_LOGGING_LEVEL` - The verbosity of the logging. Default: `info` (options: `trace`, `debug`, `info`, `warn`, `error`)
 - `MINNE_DB_CONNECTION` - The connection string for the database (e.g. `postgres://postgres:postgres@localhost:5432/minne`)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Build the backend container by going into the root directory of the repository a
 `curl --verbose http://127.0.0.1:5842/v1/task/list -H @access_token.tmp`
 
 ### Create a new Personal Access Token (PAT) for the logged-in user
-`curl --verbose http://127.0.0.1:5842/v1/auth/pat -H "Content-Type: application/json" -H @access_token.tmp --data "{\"name\": \"A descriptive name for the PAT\"}" | grep -oP '(?<=token":")[^"]*|(?<=secret":")[^"]*' | sed -z 's/\n/:/' >> pat_token.tmp`
+`echo -n "Authorization: PAT " > pat_token.tmp && curl --verbose http://127.0.0.1:5842/v1/auth/pat -H "Content-Type: application/json" -H @access_token.tmp --data "{\"name\": \"A descriptive name for the PAT\"}" | grep -oP '(?<=token":")[^"]*|(?<=secret":")[^"]*' | sed -z 's/\n/:/' >> pat_token.tmp`
+
+### Permanently disable a Personal Access Token (PAT)
+`curl --verbose http://127.0.0.1:5842/v1/auth/pat -H "Content-Type: application/json" -H @pat_token.tmp -XDELETE`
+
+**Note**: To be able to use this call, you have to use the PAT you want to disable as the access token.
 
 ## Environment Variables
 - `MINNE_LOGGING_LEVEL` - The verbosity of the logging. Default: `info` (options: `trace`, `debug`, `info`, `warn`, `error`)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Build the backend container by going into the root directory of the repository a
 `curl --verbose http://127.0.0.1:5842/v1/task/list -H @access_token.tmp`
 
 ### Create a new Personal Access Token (PAT) for the logged-in user
-`curl --verbose http://127.0.0.1:5842/v1/auth/pat -H "Content-Type: application/json" -H @access_token.tmp --data "{\"name\": \"A descriptive name for the PAT\"}"`
+`curl --verbose http://127.0.0.1:5842/v1/auth/pat -H "Content-Type: application/json" -H @access_token.tmp --data "{\"name\": \"A descriptive name for the PAT\"}" | grep -oP '(?<=token":")[^"]*|(?<=secret":")[^"]*' | sed -z 's/\n/:/' >> pat_token.tmp`
 
 ## Environment Variables
 - `MINNE_LOGGING_LEVEL` - The verbosity of the logging. Default: `info` (options: `trace`, `debug`, `info`, `warn`, `error`)

--- a/migrations/2023-01-27-071243_create_pat/down.sql
+++ b/migrations/2023-01-27-071243_create_pat/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE personal_access_tokens;

--- a/migrations/2023-01-27-071243_create_pat/up.sql
+++ b/migrations/2023-01-27-071243_create_pat/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS personal_access_tokens
+(
+    id         serial PRIMARY KEY,
+    name       varchar(255) NOT NULL, -- name which describes the token
+    token      varchar(36)  NOT NULL, -- will ne an UUID
+    secret     varchar(36)  NOT NULL,-- will ne an UUID
+    user_id    int          NOT NULL,
+    created_at timestamp    NOT NULL DEFAULT NOW(),
+    updated_at timestamp    NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (user_id) REFERENCES users (id)
+);

--- a/migrations/2023-01-27-130939_add_disabled_flag_for_pat/down.sql
+++ b/migrations/2023-01-27-130939_add_disabled_flag_for_pat/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE personal_access_tokens
+    DROP COLUMN disabled;

--- a/migrations/2023-01-27-130939_add_disabled_flag_for_pat/up.sql
+++ b/migrations/2023-01-27-130939_add_disabled_flag_for_pat/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE personal_access_tokens
+    ADD COLUMN disabled boolean NOT NULL DEFAULT false;

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -6,8 +6,8 @@ use rocket::Request;
 pub struct AuthenticatedUser {
     /// The internally used ID for the current user.
     pub id: i32,
-    /// The email address of the user.
-    pub email: String,
+    /// The Personal Access Token which was used or an empty string if the user used a access token.
+    pub used_pat: String,
 }
 
 #[derive(Debug)]
@@ -116,7 +116,7 @@ impl<'r> FromRequest<'r> for AuthenticatedUser {
                 // call the route
                 return Outcome::Success(AuthenticatedUser {
                     id: user_id,
-                    email: decoded_token.claims.sub,
+                    used_pat: "".to_string(),
                 });
             }
             _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,9 @@ async fn main() {
     use log::{debug, error, info};
     use minne_backend::fairings::{BackendConfiguration, MinneDatabaseConnection, NoCacheFairing};
     use minne_backend::routes::{
-        auth::get_authentication_token, health::check_backend_health, task::add_new_task,
-        task::delete_task, task::get_all_tasks_from_user, user::create_new_user,
-        version::get_backend_version,
+        auth::create_new_pat, auth::get_authentication_token, health::check_backend_health,
+        task::add_new_task, task::delete_task, task::get_all_tasks_from_user,
+        user::create_new_user, version::get_backend_version,
     };
     use rocket::config::{Shutdown, Sig};
     use rocket::figment::{
@@ -253,7 +253,8 @@ async fn main() {
                 get_authentication_token,
                 add_new_task,
                 delete_task,
-                get_all_tasks_from_user
+                get_all_tasks_from_user,
+                create_new_pat
             ],
         )
         .launch()

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,9 @@ async fn main() {
     use log::{debug, error, info};
     use minne_backend::fairings::{BackendConfiguration, MinneDatabaseConnection, NoCacheFairing};
     use minne_backend::routes::{
-        auth::create_new_pat, auth::get_authentication_token, health::check_backend_health,
-        task::add_new_task, task::delete_task, task::get_all_tasks_from_user,
-        user::create_new_user, version::get_backend_version,
+        auth::create_new_pat, auth::disable_pat, auth::get_authentication_token,
+        health::check_backend_health, task::add_new_task, task::delete_task,
+        task::get_all_tasks_from_user, user::create_new_user, version::get_backend_version,
     };
     use rocket::config::{Shutdown, Sig};
     use rocket::figment::{
@@ -254,7 +254,8 @@ async fn main() {
                 add_new_task,
                 delete_task,
                 get_all_tasks_from_user,
-                create_new_pat
+                create_new_pat,
+                disable_pat
             ],
         )
         .launch()

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -115,7 +115,7 @@ pub async fn disable_pat(
     db_connection_pool: &State<MinneDatabaseConnection>,
     authenticated_user: AuthenticatedUser,
 ) -> Status {
-    use crate::schema::personal_access_tokens::{disabled, table, token};
+    use crate::schema::personal_access_tokens::{disabled, table, token, updated_at};
     use diesel::ExpressionMethods;
     use diesel::RunQueryDsl;
     use log::error;
@@ -140,7 +140,7 @@ pub async fn disable_pat(
     // set the personal access token to disabled based on the use personal access token for authentication
     diesel::update(table)
         .filter(token.eq(authenticated_user.used_pat))
-        .set(disabled.eq(true))
+        .set((disabled.eq(true), updated_at.eq(diesel::dsl::now)))
         .execute(db_connection)
         .unwrap();
 

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,9 +1,16 @@
 use crate::fairings::{BackendConfiguration, MinneDatabaseConnection};
+use crate::guards::AuthenticatedUser;
 use rocket::http::Status;
 use rocket::post;
 use rocket::serde::json::Json;
 use rocket::State;
 use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct NewPersonalAccessTokenData {
+    /// The name of the new personal access token.
+    pub name: String,
+}
 
 #[derive(Deserialize)]
 pub struct Credentials {
@@ -72,6 +79,15 @@ fn get_token_for_user(
 
     // if we fail, return None
     None
+}
+
+#[post("/auth/pat", data = "<new_pata_data>")]
+pub async fn create_new_pat(
+    db_connection_pool: &State<MinneDatabaseConnection>,
+    authenticated_user: AuthenticatedUser,
+    new_pata_data: Json<NewPersonalAccessTokenData>,
+) -> Status {
+    Status::NotImplemented
 }
 
 #[post("/auth/login", data = "<credentials>")]

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -42,6 +42,7 @@ pub struct PersonalAccessToken {
     pub token: String,
     pub secret: String,
     pub user_id: i32,
+    pub disabled: bool,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,18 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    personal_access_tokens (id) {
+        id -> Int4,
+        name -> Varchar,
+        token -> Varchar,
+        secret -> Varchar,
+        user_id -> Int4,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     tasks (id) {
         id -> Int4,
         title -> Varchar,
@@ -23,6 +35,7 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(personal_access_tokens -> users (user_id));
 diesel::joinable!(tasks -> users (owner));
 
-diesel::allow_tables_to_appear_in_same_query!(tasks, users,);
+diesel::allow_tables_to_appear_in_same_query!(personal_access_tokens, tasks, users,);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -9,6 +9,7 @@ diesel::table! {
         user_id -> Int4,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        disabled -> Bool,
     }
 }
 


### PR DESCRIPTION
For enabling the app to authenticate with the backend, we should have an Personal Access token for the App which does not expire automatically. The token which the user get is too short-lived to be able to use it for this case.

This will fix issue #19 