### PR TITLE
Add an option to edit an existing task

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Build the backend container by going into the root directory of the repository a
 ### Get a task by its id with a users Personal Access Token (PAT)
 `curl --verbose http://127.0.0.1:5842/v1/task/4 -H "Content-Type: application/json" -H @pat_token.tmp`
 
+### Update the title and update_time of the task with the id 4 using a users Personal Access Token (PAT)
+`curl --verbose http://127.0.0.1:5842/v1/task/4 -H "Content-Type: application/json" -H @pat_token.tmp -XPUT --data "{\"title\": \"Some new title\",\"updated_at\":\"2023-01-01T00:00:01Z\"}"`
+
 ## Environment Variables
 - `MINNE_LOGGING_LEVEL` - The verbosity of the logging. Default: `info` (options: `trace`, `debug`, `info`, `warn`, `error`)
 - `MINNE_DB_CONNECTION` - The connection string for the database (e.g. `postgres://postgres:postgres@localhost:5432/minne`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn main() {
     use minne_backend::fairings::{BackendConfiguration, MinneDatabaseConnection, NoCacheFairing};
     use minne_backend::routes::{
         auth::create_new_pat, auth::disable_pat, auth::get_authentication_token,
-        health::check_backend_health, task::add_new_task, task::delete_task,
+        health::check_backend_health, task::add_new_task, task::delete_task, task::edit_task,
         task::get_all_task_ids_from_user, task::get_task, user::create_new_user,
         version::get_backend_version,
     };
@@ -258,6 +258,7 @@ async fn main() {
                 create_new_pat,
                 disable_pat,
                 get_task,
+                edit_task,
             ],
         )
         .launch()

--- a/src/routes/task.rs
+++ b/src/routes/task.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::State;
-use rocket::{delete, get, post};
+use rocket::{delete, get, post, put};
 use serde::{Deserialize, Serialize};
 
 #[derive(Queryable)]
@@ -89,6 +89,11 @@ pub async fn get_all_task_ids_from_user(
 
     // return the fetch list of task ids
     return Ok(Json(task_ids));
+}
+
+#[put("/task")]
+pub async fn edit_task() -> Status {
+    Status::NotImplemented
 }
 
 #[post("/task", data = "<new_task_data>")]


### PR DESCRIPTION
Tasks have to be editable to make them usable. Therefore, there  should be an PUT route to edit an existing task.

This will fulfill issue #13 